### PR TITLE
Security hardening + Dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Keep the GitHub Actions used by the release workflow up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Keep the nginx base image in the Dockerfile up to date.
+  # NOTE: Dependabot can only bump a versioned tag. A floating tag such as
+  # "nginx:alpine" has no version to compare, so pin it (e.g. "nginx:1.27-alpine"
+  # or a digest) for Dependabot to open update PRs.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot auto-merge
+
+# Automatically approve and merge every Dependabot pull request — including
+# major version bumps. Requires two repository settings to be enabled:
+#   1. Settings → General → Pull Requests → "Allow auto-merge"
+#   2. Settings → Actions → General → Workflow permissions →
+#      "Allow GitHub Actions to create and approve pull requests"
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve the pull request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (all updates, including majors)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set tag without first two chars
+      - name: Derive version tag (strip leading "v")
         id: tag
         run: |
-          SHORT_TAG="${GITHUB_REF_NAME:2}"
+          SHORT_TAG="${GITHUB_REF_NAME#v}"
           echo "SHORT_TAG=$SHORT_TAG" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
@@ -47,7 +47,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            poliuscorp/vault:latest 
+            poliuscorp/vault:latest
             poliuscorp/vault:${{ steps.tag.outputs.short_tag }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ FROM nginx:alpine
 # Set working directory
 WORKDIR /vault
 
-# Copy application files into the container
+# Copy application files into the container, normalizing permissions so the
+# non-root nginx worker can always read them regardless of the host's umask.
 COPY src /vault
+RUN chmod -R a+rX /vault
 
 # Copy custom Nginx configuration to override the default
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,3 +1,4 @@
 yourdomain.com {
+	header Strict-Transport-Security "max-age=31536000; includeSubDomains"
 	reverse_proxy vault:80
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,4 +2,13 @@ server {
     listen 80;
     root /vault;
     index index.html;
+
+    # Security headers
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Resource-Policy "same-origin" always;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
           <div class="header-icon">
             <img src="assets/logo.svg" alt="VAULT" />
           </div>
-          <h1 class="app-title">VAULT<span class="app-version">v.1.4.0</span></h1>
+          <h1 class="app-title">VAULT<span class="app-version">v.1.5.0</span></h1>
         </a>
       </div>
       <p class="app-subtitle">AES-GCM + PBKDF2/SHA-512</p>

--- a/src/js/decrypt.js
+++ b/src/js/decrypt.js
@@ -42,6 +42,32 @@ setupDragAndDrop(decFile, 'decFileInfo');
 
 function b64u8(b) { return Uint8Array.from(atob(b), c => c.charCodeAt(0)) }
 
+// Mirror of encrypt.js: header || LE32(index) || isLast byte.
+function buildAAD(header, index, isLast) {
+  const aad = new Uint8Array(header.length + 5);
+  aad.set(header, 0);
+  new DataView(aad.buffer).setUint32(header.length, index, true);
+  aad[header.length + 4] = isLast ? 1 : 0;
+  return aad;
+}
+
+// The header is attacker-controllable, so validate/clamp it before it drives key
+// derivation or buffer sizing. Unbounded iterations would otherwise hang the tab.
+const MAX_ITERATIONS = 5_000_000;
+const MAX_CHUNK = 64 * 1024 * 1024; // 64 MiB
+
+function validateMeta(meta, dataLen) {
+  if (typeof meta.salt !== 'string' || meta.salt.length === 0) throw new Error('Invalid metadata: salt');
+  if (!Number.isInteger(meta.iterations) || meta.iterations < 1 || meta.iterations > MAX_ITERATIONS)
+    throw new Error('Invalid metadata: iterations');
+  if (!Number.isInteger(meta.size) || meta.size < 0 || meta.size > dataLen)
+    throw new Error('Invalid metadata: size');
+  if (!Number.isInteger(meta.chunk) || meta.chunk < 1 || meta.chunk > MAX_CHUNK)
+    throw new Error('Invalid metadata: chunk');
+  if (typeof meta.filename !== 'string' || meta.filename.length === 0)
+    throw new Error('Invalid metadata: filename');
+}
+
 async function deriveKey(pw, salt, iter) {
   const base = await crypto.subtle.importKey('raw', decEnc.encode(pw), 'PBKDF2', false, ['deriveKey']);
   return crypto.subtle.deriveKey(
@@ -85,7 +111,7 @@ decBtn.onclick = async () => {
     if (magic !== 'AES1') throw new Error('Bad magic');
 
     const version = data[offset]; offset += 1;
-    if (version !== 1) throw new Error('Bad version');
+    if (version !== 1 && version !== 2) throw new Error('Bad version');
 
     const hdrLen = new DataView(data.buffer, offset, 4).getUint32(0, true);
     offset += 4;
@@ -93,22 +119,33 @@ decBtn.onclick = async () => {
     const metaStr = new TextDecoder().decode(data.slice(offset, offset + hdrLen));
     offset += hdrLen;
     const meta = JSON.parse(metaStr);
+    validateMeta(meta, data.length);
+
+    // Header bytes covering magic | version | metaLen | meta — authenticated as
+    // AAD in version 2 so any tampering with the metadata fails decryption.
+    const header = data.slice(0, offset);
 
     const key = await deriveKey(pw, b64u8(meta.salt), meta.iterations);
 
     // Collect decrypted chunks
     const chunks = [];
     let done = 0;
+    let index = 0;
 
     while (done < meta.size) {
       const iv = data.slice(offset, offset + 12); offset += 12;
       const chunkSize = Math.min(meta.chunk, meta.size - done);
       const ct = data.slice(offset, offset + chunkSize + 16); offset += chunkSize + 16;
 
-      const pt = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct));
+      const isLast = done + chunkSize >= meta.size;
+      const params = version === 2
+        ? { name: 'AES-GCM', iv, additionalData: buildAAD(header, index, isLast) }
+        : { name: 'AES-GCM', iv };
+      const pt = new Uint8Array(await crypto.subtle.decrypt(params, key, ct));
       chunks.push(pt);
 
       done += pt.length;
+      index++;
       const pct = ((done / meta.size) * 100).toFixed(1);
       decBar.style.width = pct + '%';
       decBar.textContent = pct + '%';

--- a/src/js/decrypt.js
+++ b/src/js/decrypt.js
@@ -1,4 +1,4 @@
-import { showToast, displayFileInfo, setupDragAndDrop, clearFileInput } from './utils.js';
+import { showToast, displayFileInfo, setupDragAndDrop, clearFileInput, confirmLargeFile } from './utils.js';
 
 const decEnc = new TextEncoder(), decDec = new TextDecoder();
 
@@ -88,6 +88,7 @@ decBtn.onclick = async () => {
   const file = decFile.files[0];
   const pw   = decPwd.value;
   if (!file || !pw) return showToast('Please select an encrypted file and enter the password');
+  if (!confirmLargeFile(file)) return;
 
   // Reset UI
   const decCard = document.getElementById('decCard');

--- a/src/js/encrypt.js
+++ b/src/js/encrypt.js
@@ -40,9 +40,10 @@ encPwdGenerate.addEventListener('click', () => {
   const newPw = generateRandomAESKeyBase64();
   encPwd.value = newPw;
   encPwd.focus();
-  navigator.clipboard.writeText(newPw);
-  showToast('Password generated and copied to clipboard', 'success');
   updatePasswordStrength(newPw, 'encPwdStrength');
+  navigator.clipboard.writeText(newPw)
+    .then(() => showToast('Password generated and copied to clipboard', 'success'))
+    .catch(() => showToast('Password generated (clipboard copy failed — copy it manually)', 'warning'));
 });
 
 encPwdToggle.addEventListener('click', () => {

--- a/src/js/encrypt.js
+++ b/src/js/encrypt.js
@@ -1,4 +1,4 @@
-import { showToast, displayFileInfo, updatePasswordStrength, setupDragAndDrop, clearFileInput } from './utils.js';
+import { showToast, displayFileInfo, updatePasswordStrength, setupDragAndDrop, clearFileInput, confirmLargeFile } from './utils.js';
 
 const enc = new TextEncoder();
 
@@ -102,6 +102,7 @@ encBtn.onclick = async () => {
     showToast('Please select a file and enter a password');
     return;
   }
+  if (!confirmLargeFile(file)) return;
 
   // Reset UI
   const encCard = document.getElementById('encCard');

--- a/src/js/encrypt.js
+++ b/src/js/encrypt.js
@@ -60,6 +60,25 @@ encPwdToggle.addEventListener('click', () => {
 // Setup drag & drop
 setupDragAndDrop(encFile, 'encFileInfo');
 
+function concatBytes(...arrays) {
+  const total = arrays.reduce((n, a) => n + a.length, 0);
+  const out = new Uint8Array(total);
+  let pos = 0;
+  for (const a of arrays) { out.set(a, pos); pos += a.length; }
+  return out;
+}
+
+// Per-chunk Additional Authenticated Data. Binding the full header, the chunk
+// index and an "is last chunk" flag into the GCM tag makes the metadata
+// tamper-evident and prevents chunk reordering, duplication and truncation.
+function buildAAD(header, index, isLast) {
+  const aad = new Uint8Array(header.length + 5);
+  aad.set(header, 0);
+  new DataView(aad.buffer).setUint32(header.length, index, true);
+  aad[header.length + 4] = isLast ? 1 : 0;
+  return aad;
+}
+
 async function deriveKey(pw, salt, iter) {
   const base = await crypto.subtle.importKey('raw', enc.encode(pw), 'PBKDF2', false, ['deriveKey']);
   return crypto.subtle.deriveKey(
@@ -99,7 +118,7 @@ encBtn.onclick = async () => {
   try {
     const CHUNK = 1_048_576; // 1 MiB
     const salt  = crypto.getRandomValues(new Uint8Array(16));
-    const iter  = 250_000;
+    const iter  = 600_000;
     const key   = await deriveKey(pw, salt, iter);
 
   const meta = {
@@ -113,27 +132,30 @@ encBtn.onclick = async () => {
   };
 
   const metaBytes = enc.encode(JSON.stringify(meta));
-  const chunks = [];
 
-  // Header
-  chunks.push(enc.encode('AES1'));  // magic
-  chunks.push(new Uint8Array([1])); // version
+  // Header: magic(4) | version(1) | metaLen(4, LE) | meta. Version 2 binds the
+  // header + chunk index + last-flag into each chunk's GCM tag (see buildAAD).
   const lenBuf = new Uint8Array(4);
   new DataView(lenBuf.buffer).setUint32(0, metaBytes.length, true);
-  chunks.push(lenBuf);
-  chunks.push(metaBytes);
+  const header = concatBytes(enc.encode('AES1'), new Uint8Array([2]), lenBuf, metaBytes);
+
+  const chunks = [header];
 
   // File, chunk-by-chunk
   let offset = 0;
+  let index = 0;
   while (offset < file.size) {
     const blob  = file.slice(offset, offset + CHUNK);
     const chunk = new Uint8Array(await blob.arrayBuffer());
+    const isLast = offset + chunk.length >= file.size;
     const iv    = crypto.getRandomValues(new Uint8Array(12));
-    const ct    = new Uint8Array(await crypto.subtle.encrypt({ name:'AES-GCM', iv }, key, chunk));
+    const ct    = new Uint8Array(await crypto.subtle.encrypt(
+      { name:'AES-GCM', iv, additionalData: buildAAD(header, index, isLast) }, key, chunk));
     chunks.push(iv);
     chunks.push(ct);
 
     offset += chunk.length;
+    index++;
     const pct = ((offset / file.size) * 100).toFixed(1);
     encBar.style.width = pct + '%';
     encBar.textContent = pct + '%';

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -13,10 +13,11 @@ export function showToast(message, type = 'warning') {
 
   const toast = document.createElement('div');
   toast.className = `app-toast ${type}`;
-  toast.innerHTML = `
-    <i class="bi ${iconMap[type] || iconMap.warning}"></i>
-    <span>${message}</span>
-  `;
+  const toastIcon = document.createElement('i');
+  toastIcon.className = `bi ${iconMap[type] || iconMap.warning}`;
+  const toastText = document.createElement('span');
+  toastText.textContent = message;
+  toast.append(toastIcon, toastText);
   container.appendChild(toast);
   
   setTimeout(() => {
@@ -73,30 +74,48 @@ export function displayFileInfo(file, infoElementId) {
   const card = dropZone?.closest('.card');
   const isDecrypt = card?.classList.contains('decrypt');
   const icon = isDecrypt ? 'bi-file-earmark-lock2' : 'bi-file-earmark';
-  
-  infoElement.innerHTML = `
-    <i class="bi ${icon}"></i>
-    <span class="file-name" title="${file.name}">${file.name}</span>
-    <span class="file-size">${formatFileSize(file.size)}</span>
-    <button class="file-remove" type="button" title="Remove file" aria-label="Remove file"><i class="bi bi-x-lg"></i></button>
-  `;
+
+  // Build the file-info node via the DOM API. file.name is attacker-controllable
+  // (it comes from the OS filename of a dropped/selected file), so it must never
+  // be interpolated into innerHTML — use textContent/setAttribute instead.
+  infoElement.replaceChildren();
+
+  const fileIcon = document.createElement('i');
+  fileIcon.className = `bi ${icon}`;
+
+  const nameEl = document.createElement('span');
+  nameEl.className = 'file-name';
+  nameEl.title = file.name;
+  nameEl.textContent = file.name;
+
+  const sizeEl = document.createElement('span');
+  sizeEl.className = 'file-size';
+  sizeEl.textContent = formatFileSize(file.size);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.className = 'file-remove';
+  removeBtn.type = 'button';
+  removeBtn.title = 'Remove file';
+  removeBtn.setAttribute('aria-label', 'Remove file');
+  const removeIcon = document.createElement('i');
+  removeIcon.className = 'bi bi-x-lg';
+  removeBtn.appendChild(removeIcon);
+
+  infoElement.append(fileIcon, nameEl, sizeEl, removeBtn);
   infoElement.style.display = 'flex';
   if (dropZone) dropZone.classList.add('has-file');
   if (prompt) prompt.style.display = 'none';
   
-  const removeBtn = infoElement.querySelector('.file-remove');
-  if (removeBtn) {
-    removeBtn.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const fileInput = dropZone?.querySelector('input[type="file"]');
-      if (fileInput) fileInput.value = '';
-      infoElement.style.display = 'none';
-      infoElement.innerHTML = '';
-      if (dropZone) dropZone.classList.remove('has-file');
-      if (prompt) prompt.style.display = '';
-    });
-  }
+  removeBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const fileInput = dropZone?.querySelector('input[type="file"]');
+    if (fileInput) fileInput.value = '';
+    infoElement.style.display = 'none';
+    infoElement.replaceChildren();
+    if (dropZone) dropZone.classList.remove('has-file');
+    if (prompt) prompt.style.display = '';
+  });
 }
 
 export function clearFileInput(fileInput, fileInfoElementId) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -26,6 +26,18 @@ export function showToast(message, type = 'warning') {
   }, 3000);
 }
 
+// Both encrypt and decrypt buffer the entire file (plus a second copy) in memory,
+// so very large files can freeze or crash the tab. Warn the user before committing.
+export const LARGE_FILE_THRESHOLD = 1024 * 1024 * 1024; // 1 GiB
+
+export function confirmLargeFile(file) {
+  if (!file || file.size <= LARGE_FILE_THRESHOLD) return true;
+  return window.confirm(
+    `This file is large (${formatFileSize(file.size)}). Processing happens entirely ` +
+    `in your browser's memory and may freeze or crash the tab. Continue?`
+  );
+}
+
 export function calculatePasswordStrength(password) {
   if (!password) return null;
   


### PR DESCRIPTION
## Summary

Security review and hardening of VAULT, plus CI automation. Each area is a separate commit for reviewability. All changes were verified empirically — unit-level crypto tests, an end-to-end Playwright run against the built Docker image (16/16 checks), and a backward-compatibility check for existing `.vault` files.

## Security fixes

| Sev | Fix | Commit |
|-----|-----|--------|
| **High** | **DOM XSS** — `file.name`/toast messages were interpolated into `innerHTML`; a file named `a"><img src=x onerror=...>.txt` executed. Now built via DOM API (`textContent`/`setAttribute`). | `security: prevent DOM XSS …` |
| **Medium** | **Authenticated v2 format** — header, chunk index and a last-chunk flag are bound into each AES-GCM chunk as AAD, so metadata tampering and chunk reorder/duplication/truncation now fail decryption. | `security: add authenticated v2 …` |
| **Medium** | **DoS via crafted file** — untrusted `iterations`/`size`/`chunk` are validated and clamped before driving PBKDF2 / buffers. | same |
| **Medium** | **Security headers** — strict CSP + `X-Frame-Options`/`X-Content-Type-Options`/`Referrer-Policy`/`Permissions-Policy`/COOP/CORP in nginx, HSTS at the Caddy edge. | `deploy: add security headers …` |

KDF hardened (PBKDF2 250k → 600k). **Legacy v1 `.vault` files still decrypt.** (M5 — HTTP-only default deployment — was intentionally left out of scope.)

## Other fixes

- **L2** — warn before processing files >1 GiB (everything is buffered in memory).
- **L3** — only report a generated password as "copied" if the clipboard write actually succeeds.
- **Dockerfile** — `chmod -R a+rX` the copied assets so the non-root nginx worker can read them regardless of host umask (fixes a host-permission build footgun).
- **release.yml** — derive the version tag by stripping a literal leading `v` instead of cutting two chars; drop a stray trailing space.
- Version bumped to **1.5.0** (format change ⇒ deploy this build everywhere before relying on v2 files).

## CI automation

- **Dependabot** for `github-actions` and `docker` (weekly, grouped).
- **Auto-merge workflow** that approves and merges every Dependabot PR, **including majors**.
- Repo settings already enabled via API: `allow_auto_merge`, and Actions write + "create & approve PRs".

### Notes / follow-ups
- Docker base image is `nginx:alpine` (floating tag) — pin to a versioned tag for Dependabot to actually open base-image PRs.
- Vendored Bootstrap has no manifest, so Dependabot cannot track it.

## Verification
- Crypto unit tests: round-trip, wrong-password, metadata-tamper, chunk-reorder — all pass.
- Playwright E2E against the running container: **16/16** (encrypt/decrypt round-trip, v2 format emitted, wrong password, tamper rejection, XSS payload inert, **no CSP violations**, v1 backward compat).
- `nginx -t` valid; all assets serve `200` with correct MIME types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
