### PR TITLE
ci: fix release tag derivation (v. prefix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Derive version tag (strip leading "v")
+      - name: Derive version tag (strip leading "v.")
         id: tag
         run: |
-          SHORT_TAG="${GITHUB_REF_NAME#v}"
+          SHORT_TAG="${GITHUB_REF_NAME#v.}"
           echo "SHORT_TAG=$SHORT_TAG" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image


### PR DESCRIPTION
The 1.5.0 release build failed with an invalid Docker tag \`poliuscorp/vault:.1.5.0\`.

The repo tags releases as \`v.X.Y.Z\` (v + dot). The tag-derivation step stripped only a leading \`v\`, leaving the dot. This strips the literal \`v.\` prefix so the image tag becomes \`X.Y.Z\` again.

After merge, the broken v.1.5.0 release/tag will be deleted and recreated to trigger a correct build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)